### PR TITLE
Mask remote failures in inventory code

### DIFF
--- a/root/usr/sbin/nethserver-inventory
+++ b/root/usr/sbin/nethserver-inventory
@@ -95,11 +95,8 @@ trap "{ rm -f $TMP; }" SIGINT SIGTERM EXIT
 
 echo "{\"data\": {\"lk\": \"$systemid\", \"data\": $json}}" > $TMP
 
-code=`/usr/bin/curl $debug -L -w "%{http_code}" -X POST \
+/usr/bin/curl $debug -L -X POST \
    --header "Authorization: token $secret" $auth --header "Content-Type: application/json" --header "Accept: application/json"  \
-   --data-binary @$TMP \
-   $url`
+   --data-binary @$TMP $url
 
-if [ "$code" != "200" ]; then
-   exit 1
-fi
+exit 0


### PR DESCRIPTION
Retain the legacy behavior to not check for remote failures when sending
the inventory. Needs a fix on the server side.

https://github.com/NethServer/dev/issues/5425