### PR TITLE
Fix ns6 (Enterprise) upgrades

### DIFF
--- a/root/etc/e-smith/templates/etc/yum/vars/nsrelease/10base
+++ b/root/etc/e-smith/templates/etc/yum/vars/nsrelease/10base
@@ -5,7 +5,12 @@
     $systemId = $subscription{'SystemId'} || $nethupdate{'SystemID'} || "";
 
     if ($systemId ne "") {
-        $OUT = $subscription{'NsRelease'} || $nethupdate{'NsRelease'} || '';
+        my $defaultRelease = do {
+            open my $nsh, "<", '/etc/e-smith/db/configuration/force/sysconfig/Version';
+            <$nsh>;
+        };
+        chomp($defaultRelease);
+        $OUT = $subscription{'NsRelease'} || $nethupdate{'NsRelease'} || $defaultRelease;
     } else {
         $OUT = '';
     }


### PR DESCRIPTION
Prepare a fallback value for upgrades from ns6, where NsRelease is not defined. This is a supported scenario in Enterprise versions, but can apply to NethServer subscription too.

Nethesis/dev#5364