### PR TITLE
Fix unexisting variable name

### DIFF
--- a/root/etc/e-smith/templates/etc/yum/vars/nsrelease/20subscription
+++ b/root/etc/e-smith/templates/etc/yum/vars/nsrelease/20subscription
@@ -5,7 +5,7 @@
     $systemId = $subscription{'SystemId'} || $nethupdate{'SystemID'} || "";
 
     if ($systemId ne "") {
-        $release = $subscription{'NsRelease'} || $nethupdate{'NsRelease'} || $defaultRelease;
+        $release = $subscription{'NsRelease'} || $nethupdate{'NsRelease'} || $release;
     }
 
     '';

--- a/root/etc/e-smith/templates/etc/yum/vars/nsrelease/20subscription
+++ b/root/etc/e-smith/templates/etc/yum/vars/nsrelease/20subscription
@@ -5,7 +5,17 @@
     $systemId = $subscription{'SystemId'} || $nethupdate{'SystemID'} || "";
 
     if ($systemId ne "") {
-        $release = $subscription{'NsRelease'} || $nethupdate{'NsRelease'} || $release;
+        my $nextRelease = do {
+            # Read from filesystem because the config DB can be overridden
+            # by the "pre-restore-config" event:
+            open my $nsh, "<", '/etc/e-smith/db/configuration/force/subscription/NsRelease';
+            <$nsh>;
+        };
+        chomp $nextRelease;
+
+        # Override the system release with the next release number to
+        # start an automatic system upgrade:
+        $release = $nextRelease || $release;
     }
 
     '';


### PR DESCRIPTION
* Retrieve the next version number from the filesystem because the DB value can be inconsistent during `pre-restore-config` event
* Fall back to the existing $release value if the next version number is
missing

https://github.com/NethServer/dev/issues/5724