### PR TITLE
inventory: suppress backup warning

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/backup.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/backup.rb
@@ -7,6 +7,9 @@ Facter.add('backup') do
         backup = {}
         # Find most recent log file
         log_file = Dir.glob("/var/log/backup/backup-*").max_by {|f| File.mtime(f)}
+        if log_file == nil
+            next backup
+        end
 
         # Extract name
         parts = log_file.split('-')


### PR DESCRIPTION
If backup has never been executed avoid error:
 ERROR puppetlabs.facter - error while resolving custom fact "backup": undefined method `split' for nil:NilClass