### PR TITLE
spec: obsolete sclo-php71-php-pecl-imagick

### DIFF
--- a/nethserver-subscription.spec
+++ b/nethserver-subscription.spec
@@ -23,6 +23,9 @@ Requires: curl
 Requires: jq
 Requires: %{name}-inventory
 
+# HACK: allow upgrade from NS 7.7 where sclo-php71-php-pecl-imagick was installed
+Obsoletes: sclo-php71-php-pecl-imagick <= 3.4.4
+
 %description
 NethServer Subscriptions
 


### PR DESCRIPTION
The sclo-php71-php-pecl-imagick package was a requirement for Nextcloud
15. The package is no more required by any package, but on old machines,
the RPM could be still present.

The package can be safely removed since it has been already discontinued also by
upstream.

**Note**: `nethserver-subscription` does not provide `sclo-php71-php-pecl-imagick` because the packages is effectively deprecated and not provided by any other package.

NethServer/dev#6156