### PR TITLE
Collect the reason of systemd restart events

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
@@ -24,7 +24,7 @@ Facter.add('systemd') do
         systemd = {
             "restart" => {}
         }
-        tmp = Facter::Core::Execution.execute("zgrep ', status=' /var/log/messages* | awk '{print $6,$11}' | sort | uniq -c")
+        tmp = Facter::Core::Execution.execute("zgrep ', status=' /var/log/messages* | awk '{print $6,$11}' | sort | uniq -c", :timeout => 60)
         tmp.split(/(\s+)?\n(\s+)?/).each do |record|
             fields = record.split(/\s+/)
             if fields.length() < 3 || !fields[2].start_with?('status=') then

--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
@@ -1,0 +1,20 @@
+# systemd.rb
+
+Facter.add('systemd') do
+    confine osfamily: 'RedHat'
+    setcode do
+        systemd = {
+            "timestamp" => Time.now.to_i,
+            "restart" => {}
+        }
+        tmp = Facter::Core::Execution.execute("zgrep ', status=' /var/log/messages* | awk '{print $6,$11}' | sort | uniq -c")
+        tmp.split(/(\s+)?\n(\s+)?/).each do |record|
+            fields = record.split(/\s+/)
+            if fields.length() < 3 || !fields[2].start_with?('status=') then
+              next
+            end
+            systemd["restart"][fields[1] + fields[2]] = Integer(fields[0])
+        end
+        systemd
+    end
+end

--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
@@ -1,4 +1,22 @@
-# systemd.rb
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
 
 Facter.add('systemd') do
     confine osfamily: 'RedHat'

--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
@@ -22,7 +22,6 @@ Facter.add('systemd') do
     confine osfamily: 'RedHat'
     setcode do
         systemd = {
-            "timestamp" => Time.now.to_i,
             "restart" => {}
         }
         tmp = Facter::Core::Execution.execute("zgrep ', status=' /var/log/messages* | awk '{print $6,$11}' | sort | uniq -c")


### PR DESCRIPTION
Each restart reason is counted separately.

Both `/var/log/messages` and any (maybe compressed) archive of it are considered.  The command takes less than one second to run on a cheap server with one year of zipped log archives.

Counters might result as decreased after a log archive has been expunged, however the relevant event is only a counter increment since the last run. If both happens in the same day the relevant event cannot be intercepted. This is a known limitation that should not harm. 

This is a sample output:

    # facter -j systemd


```json
{
  "systemd": {
    "restart": {
      "asterisk.service:status=233/RUNTIME_DIRECTORY": 3,
      "asterisk.service:status=9/KILL": 4,
      "httpd-admin.service:status=1/FAILURE": 1,
      "janus-gateway.service:status=1/FAILURE": 168,
      "kdump.service:status=1/FAILURE": 6,
      "nethcti-server.service:status=1/FAILURE": 2,
      "nethvoice-alerts.service:status=1/FAILURE": 158,
      "phonebookjs.service:status=1/FAILURE": 2,
      "phonebookjss.service:status=1/FAILURE": 279
    }
  }
}
```

nethesis/dev#5854