### PR TITLE
Fix RPM duplicate files

### DIFF
--- a/nethserver-subscription.spec
+++ b/nethserver-subscription.spec
@@ -40,7 +40,7 @@ cp -a lib/nethserver_alerts.py root%{python2_sitelib}
 
 %install
 (cd root; find . -depth -print | sed \
-        -e '\|^/opt| d' \
+        -e '\|^\./opt| d' \
         -e '\|/etc/cron.daily/nethserver-inventory| d' \
         -e '\|/usr/sbin/nethserver-inventory| d' \
         -e '\|/usr/sbin/ardad| d' \

--- a/nethserver-subscription.spec
+++ b/nethserver-subscription.spec
@@ -40,15 +40,15 @@ cp -a lib/nethserver_alerts.py root%{python2_sitelib}
 
 %install
 (cd root; find . -depth -print | sed \
+        -e '\|^/opt| d' \
         -e '\|/etc/cron.daily/nethserver-inventory| d' \
         -e '\|/usr/sbin/nethserver-inventory| d' \
         -e '\|/usr/sbin/ardad| d' \
         -e '\|/etc/e-smith/events/actions/nethserver-inventory-send| d' \
     | cpio -dump %{buildroot})
 %{genfilelist} \
-    --ignoredir '/opt' %{buildroot} \
     --file /etc/sudoers.d/20_nethserver_subscription 'attr(0440,root,root)' \
-    > filelist
+    %{buildroot} > filelist
 
 # 1. Split UI parts from core package
 grep -E ^%{_nsuidir}/ filelist > filelist-ui


### PR DESCRIPTION
Ruby files under /opt are owned by both nethserver-subscription-inventory and nethserver-subscription

```text
[root@vm1 ~]# rpm -qf /opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/systemd.rb
nethserver-subscription-inventory-3.6.3-1.ns7.x86_64
nethserver-subscription-3.6.3-1.ns7.noarch
```

NethServer/dev#6278