### PR TITLE
facter. esmithdb: remove hidden files

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/esmithdb.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/esmithdb.rb
@@ -7,7 +7,7 @@ Facter.add('esmithdb') do
     setcode do
         dbs = {}
         Dir.entries('/var/lib/nethserver/db').each do |db|
-            next if (db == '.') || (db == '..')
+            next if (db =~ /^\./)
             tmp = Facter::Core::Execution.exec("/sbin/e-smith/db #{db} printjson")
             data = JSON.parse(tmp)
             data.each_with_index do |item, index|


### PR DESCRIPTION
When a swap file remains inside the `/var/lib/nethserver/db` directory, during inventory calculation, facter produces a bad encoding on swap file.

The swap file must be not present inside the directory, with this PR we remove all hidden files.

https://github.com/nethesis/dev/issues/5874