### PR TITLE
lsm alert: include nslabel if present

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-alerts-lsm-update
+++ b/root/etc/e-smith/events/actions/nethserver-alerts-lsm-update
@@ -16,9 +16,9 @@ PREVSTATE=${15}
 TIMESTAMP=${16}
 
 interface=$(/sbin/e-smith/db networks getprop $NAME interface)
-if [ ! -z $interface ]; then
+if [ -n "$interface" ]; then
     label=$(/sbin/e-smith/db networks getprop $interface nslabel)
-    if [ ! -z $label ]; then
+    if [ -n "$label" ]; then
         NAME=$label
     fi
 fi

--- a/root/etc/e-smith/events/actions/nethserver-alerts-lsm-update
+++ b/root/etc/e-smith/events/actions/nethserver-alerts-lsm-update
@@ -15,6 +15,14 @@ NAME=${2}
 PREVSTATE=${15}
 TIMESTAMP=${16}
 
+interface=$(/sbin/e-smith/db networks getprop $NAME interface)
+if [ ! -z $interface ]; then
+    label=$(/sbin/e-smith/db networks getprop $interface nslabel)
+    if [ ! -z $label ]; then
+        NAME=$label
+    fi
+fi
+
 hostname=$(hostname)
 severity=""
 


### PR DESCRIPTION
Include `nslabel` inside alarm name to better understand
which WAN changed the state

NethServer/dev#6392