### PR TITLE
public_ip fact: return an empty string on error

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/public_ip.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/public_ip.rb
@@ -3,10 +3,15 @@
 # Retrive public IP address
 #
 
+require "resolv"
+
 Facter.add('public_ip') do
     confine osfamily: 'RedHat'
     setcode do
-        public_ip = Facter::Core::Execution.exec("/usr/bin/curl ifconfig.co/")
+        public_ip = Facter::Core::Execution.exec("/usr/bin/curl -4 -m 5 ifconfig.co/")
+        if !(public_ip =~ Resolv::IPv4::Regex)
+            public_ip = ''
+        end
         public_ip
     end
 end


### PR DESCRIPTION
Changes:
- make sure to always ask only for IPv4 address
- check the curl output and make sure the fact returns a valid IPv4 address or an empty string
- add 5 seconds timeout to not block the inventory

NethServer/dev#6748